### PR TITLE
Add sys-tools: backup, host check, usage monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+backups/
+*.tar.gz
+.env

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SRC_DIR="${1:-$HOME}"
+DEST_DIR="${2:-$PWD/backups}"
+mkdir -p "$DEST_DIR"
+STAMP="$(date +%F_%H%M%S)"
+TAR="$DEST_DIR/backup_${STAMP}.tar.gz"
+tar --exclude="$DEST_DIR" -czf "$TAR" "$SRC_DIR"
+echo "Created: $TAR"

--- a/check_hosts.sh
+++ b/check_hosts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FILE="${1:-hosts.txt}"
+while IFS= read -r host; do
+  [[ -z "$host" || "$host" =~ ^# ]] && continue
+  if ping -c1 -W1 "$host" >/dev/null 2>&1; then
+    echo "[OK] $host"
+  else
+    echo "[DOWN] $host"
+  fi
+done < "$FILE"

--- a/usage_monitor.sh
+++ b/usage_monitor.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+LANG=C
+echo "=== $(date) ==="
+free -m | awk '/Mem:/ {printf("RAM: %d/%d MiB (%.1f%%)\n",$3,$2,$3/$2*100)}'
+top -b -n1 | awk -F'[, ]+' '/Cpu\(s\)/{printf("CPU: user %s, sys %s, idle %s\n",$3,$5,$9)}'
+echo "Top CPU:"
+ps -eo pid,comm,%cpu,%mem --sort=-%cpu | head -n 6


### PR DESCRIPTION
## Summary
Add three Bash admin utilities and base repo setup.

## What's inside
- `backup.sh` — creates `backups/backup_YYYY-MM-DD_HHMMSS.tar.gz` from given path.
- `check_hosts.sh` — pings hosts from `hosts.txt`, prints `[OK]/[DOWN]`.
- `usage_monitor.sh` — shows CPU/RAM usage + top CPU processes.
- `.gitignore` — ignores backups, archives, .env.

## How to test
```bash
./backup.sh "$HOME" ./backups
printf '127.0.0.1\ngoogle.com\n192.0.2.1\n' > hosts.txt && ./check_hosts.sh hosts.txt
./usage_monitor.sh
